### PR TITLE
Update the link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install @ton/core
 
 ## Reference Documentation
 
-[Documentation](https://ton-community.github.io/ton-core/)
+[Documentation](https://ton-org.github.io/ton-core/)
 
 # License
 


### PR DESCRIPTION
Updated link to documentation to ton-org github pages instead of ton-community