### PR TITLE
fix(Message): edge case with ExtraCurrency for storeMessage

### DIFF
--- a/src/types/Message.spec.ts
+++ b/src/types/Message.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Whales Corp.
+ * All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { beginCell } from "../boc/Builder";
+import { Cell } from "../boc/Cell";
+import {loadMessage, storeMessage} from "./Message";
+
+describe('Message', () => {
+    it('should handle edge case with extra currency', () => {
+        const tx = 'te6cckEBBwEA3QADs2gB7ix8WDhQdzzFOCf6hmZ2Dzw2vFNtbavUArvbhXqqqmEAMpuMhx8zp7O3wqMokkuyFkklKpftc4Dh9_5bvavmCo-UXR6uVOIGMkCwAAAAAAC3GwLLUHl_4AYCAQCA_____________________________________________________________________________________gMBPAUEAwFDoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOAUACAAAAAAAAAANoAAAAAEIDF-r-4Q';
+        const cell = Cell.fromBase64(tx);
+        const message = loadMessage(cell.beginParse());
+        let stored = beginCell()
+            .store(storeMessage(message))
+            .endCell();
+        expect(stored.equals(cell)).toBe(true);
+    });
+});

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -59,10 +59,8 @@ export function storeMessage(message: Message, opts?: { forceRef?: boolean }) {
             let needRef = false;
             if (opts && opts.forceRef) {
                 needRef = true;
-            } else if (builder.availableBits - 2 /* At least on byte for ref flag */ >= initCell.bits) {
-                needRef = false;
             } else {
-                needRef = true;
+                needRef = builder.availableBits - 2 /* At least two bits for ref flags */ < initCell.bits + message.body.bits.length;
             }
 
             // Persist init
@@ -82,12 +80,8 @@ export function storeMessage(message: Message, opts?: { forceRef?: boolean }) {
         if (opts && opts.forceRef) {
             needRef = true;
         } else {
-            if (builder.availableBits - 1 /* At least on byte for ref flag */ >= message.body.bits.length &&
-                builder.refs + message.body.refs.length <= 4) {
-                needRef = false;
-            } else {
-                needRef = true;
-            }
+            needRef = builder.availableBits - 1 /* At least one bit for ref flag */ < message.body.bits.length ||
+                builder.refs + message.body.refs.length > 4;
         }
         if (needRef) {
             builder.storeBit(true);


### PR DESCRIPTION
According to this [code](https://github.com/ton-blockchain/ton/blob/062b7b4a92dd67e32d963cf3f04b8bc97d8b7ed5/crypto/block/transaction.cpp#L2078-L2109) from the blockchain code, in case of overflow, the state init is entered first in the ref. This fix considers this detail so that there is no overflow in case ExtraCurrency + Data + Code + Libs and a shortage of bits after the cell is rewritten.