### PR TITLE
Add toAddress method.

### DIFF
--- a/src/address/Address.ts
+++ b/src/address/Address.ts
@@ -112,6 +112,14 @@ export class Address {
         }
     }
 
+    static toAddress(source: Address | string): Address {
+        if (typeof source === 'string') {
+            return Address.parse(source);
+        }
+
+        return source;
+    }
+
     static parse(source: string) {
         if (Address.isFriendly(source)) {
             return this.parseFriendly(source).address;


### PR DESCRIPTION
There is often a case when you have adress either as `string` or `Address`, but you have to pass exactly `Address` further.

To not do conditional `parse` in the client side code we could incapsulate the ogic in `toAddress` method.