### PR TITLE
More flexible merkle proof generation

### DIFF
--- a/src/boc/cell/exoticMerkleProof.ts
+++ b/src/boc/cell/exoticMerkleProof.ts
@@ -9,6 +9,7 @@
 import { BitReader } from "../BitReader";
 import { BitString } from "../BitString";
 import { Cell } from "../Cell";
+import { beginCell } from '../Builder';
 
 export function exoticMerkleProof(bits: BitString, refs: Cell[]) {
     const reader = new BitReader(bits);
@@ -48,4 +49,13 @@ export function exoticMerkleProof(bits: BitString, refs: Cell[]) {
         proofDepth,
         proofHash
     };
+}
+
+export function convertToMerkleProof(c: Cell): Cell {
+    return beginCell()
+        .storeUint(3, 8)
+        .storeBuffer(c.hash(0))
+        .storeUint(c.depth(0), 16)
+        .storeRef(c)
+        .endCell({ exotic: true });
 }

--- a/src/dict/Dictionary.spec.ts
+++ b/src/dict/Dictionary.spec.ts
@@ -121,14 +121,22 @@ describe('Dictionary', () => {
         d.set(4, 44);
         d.set(5, 55);
 
+        const dict_hash = new Builder().storeDictDirect(d).endCell().hash();
         for (let k = 1; k <= 5; k++) {
-            const proof = d.generateMerkleProof(k);
+            const proof = d.generateMerkleProof([k]);
             Cell.fromBoc(proof.toBoc());
             expect(exoticMerkleProof(proof.bits, proof.refs).proofHash).toEqual(
-                Buffer.from(
-                    'ee41b86bd71f8224ebd01848b4daf4cd46d3bfb3e119d8b865ce7c2802511de3',
-                    'hex'
-                )
+                dict_hash
+            );
+
+            // todo: parse the pruned dictionary and check the presence of the keys
+        }
+
+        for (let k = 1; k <= 3; k++) {
+            const proof = d.generateMerkleProof([k, k + 1, k + 2]);
+            Cell.fromBoc(proof.toBoc());
+            expect(exoticMerkleProof(proof.bits, proof.refs).proofHash).toEqual(
+                dict_hash
             );
         }
     });

--- a/src/dict/Dictionary.spec.ts
+++ b/src/dict/Dictionary.spec.ts
@@ -121,12 +121,12 @@ describe('Dictionary', () => {
         d.set(4, 44);
         d.set(5, 55);
 
-        const dict_hash = new Builder().storeDictDirect(d).endCell().hash();
+        const dictHash = beginCell().storeDictDirect(d).endCell().hash();
         for (let k = 1; k <= 5; k++) {
             const proof = d.generateMerkleProof([k]);
             Cell.fromBoc(proof.toBoc());
             expect(exoticMerkleProof(proof.bits, proof.refs).proofHash).toEqual(
-                dict_hash
+                dictHash
             );
 
             // todo: parse the pruned dictionary and check the presence of the keys
@@ -136,7 +136,7 @@ describe('Dictionary', () => {
             const proof = d.generateMerkleProof([k, k + 1, k + 2]);
             Cell.fromBoc(proof.toBoc());
             expect(exoticMerkleProof(proof.bits, proof.refs).proofHash).toEqual(
-                dict_hash
+                dictHash
             );
         }
     });

--- a/src/dict/Dictionary.ts
+++ b/src/dict/Dictionary.ts
@@ -12,7 +12,7 @@ import { Cell } from "../boc/Cell";
 import { Slice } from "../boc/Slice";
 import { BitString } from "../boc/BitString";
 import { Maybe } from "../utils/maybe";
-import { generateMerkleProof } from "./generateMerkleProof";
+import { generateMerkleProof, generateMerkleProofDirect } from "./generateMerkleProof";
 import { generateMerkleUpdate } from "./generateMerkleUpdate";
 import { parseDict } from "./parseDict";
 import { serializeDict } from "./serializeDict";
@@ -392,8 +392,23 @@ export class Dictionary<K extends DictionaryKeyTypes, V> {
         serializeDict(prepared, resolvedKey.bits, resolvedValue.serialize, builder);
     }
 
+    /**
+     * Generate merkle proof for multiple keys in the dictionary
+     * @param keys an array of the keys
+     * @returns generated merkle proof cell
+     */
     generateMerkleProof(keys: K[]): Cell {
         return generateMerkleProof(this, keys, this._key!)
+    }
+
+    /**
+     * Low level method for generating pruned dictionary directly.
+     * The result can be used as a part of a bigger merkle proof
+     * @param keys an array of the keys
+     * @returns cell that contains the pruned dictionary
+     */
+    generateMerkleProofDirect(keys: K[]): Cell {
+        return generateMerkleProofDirect(this, keys, this._key!)
     }
 
     generateMerkleUpdate(key: K, newValue: V): Cell {

--- a/src/dict/Dictionary.ts
+++ b/src/dict/Dictionary.ts
@@ -392,8 +392,8 @@ export class Dictionary<K extends DictionaryKeyTypes, V> {
         serializeDict(prepared, resolvedKey.bits, resolvedValue.serialize, builder);
     }
 
-    generateMerkleProof(key: K): Cell {
-        return generateMerkleProof(this, key, this._key!)
+    generateMerkleProof(keys: K[]): Cell {
+        return generateMerkleProof(this, keys, this._key!)
     }
 
     generateMerkleUpdate(key: K, newValue: V): Cell {

--- a/src/dict/generateMerkleProof.ts
+++ b/src/dict/generateMerkleProof.ts
@@ -106,19 +106,25 @@ function doGenerateMerkleProof(
     }
 }
 
-export function generateMerkleProof<K extends DictionaryKeyTypes, V>(
+export function generateMerkleProofDirect<K extends DictionaryKeyTypes, V>(
     dict: Dictionary<K, V>,
     keys: K[],
     keyObject: DictionaryKey<K>
 ): Cell {
     keys = keys.filter((key) => dict.has(key)); 
     const s = beginCell().storeDictDirect(dict).asSlice();
-    return convertToMerkleProof(
-        doGenerateMerkleProof(
+    return doGenerateMerkleProof(
             '',
             s,
             keyObject.bits,
             keys.map((key) => keyObject.serialize(key).toString(2).padStart(keyObject.bits, '0'))
-        )
     );
+}
+
+export function generateMerkleProof<K extends DictionaryKeyTypes, V>(
+    dict: Dictionary<K, V>,
+    keys: K[],
+    keyObject: DictionaryKey<K>
+): Cell {
+    return convertToMerkleProof(generateMerkleProofDirect(dict, keys, keyObject));
 }

--- a/src/dict/generateMerkleProof.ts
+++ b/src/dict/generateMerkleProof.ts
@@ -68,25 +68,25 @@ function doGenerateMerkleProof(
         let right = sl.loadRef();
         // NOTE: Left and right branches are implicitly contain prefixes '0' and '1'
         if (!left.isExotic) {
-            const left_keys = keys.filter((key) => {
+            const leftKeys = keys.filter((key) => {
                 return pp + '0' === key.slice(0, pp.length + 1);
             });
             left = doGenerateMerkleProof(
                 pp + '0',
                 left.beginParse(),
                 n - prefixLength - 1,
-                left_keys
+                leftKeys
             );
         }
         if (!right.isExotic) {
-            const right_keys = keys.filter((key) => {
+            const rightKeys = keys.filter((key) => {
                 return pp + '1' === key.slice(0, pp.length + 1);
             });
             right = doGenerateMerkleProof(
                 pp + '1',
                 right.beginParse(),
                 n - prefixLength - 1,
-                right_keys
+                rightKeys
             );
         }
 

--- a/src/dict/generateMerkleProof.ts
+++ b/src/dict/generateMerkleProof.ts
@@ -24,7 +24,7 @@ function doGenerateMerkleProof(
     const originalCell = slice.asCell();
 
     if (keys.length == 0) {
-        // no keys to proof, prune the whole subdict
+        // no keys to prove, prune the whole subdict
         return convertToPrunedBranch(originalCell);
     }
 

--- a/src/dict/generateMerkleProof.ts
+++ b/src/dict/generateMerkleProof.ts
@@ -3,6 +3,7 @@ import { Cell } from '../boc/Cell';
 import { Slice } from '../boc/Slice';
 import { DictionaryKeyTypes, Dictionary, DictionaryKey } from './Dictionary';
 import { readUnaryLength } from './utils/readUnaryLength';
+import { convertToMerkleProof } from '../boc/cell/exoticMerkleProof';
 
 function convertToPrunedBranch(c: Cell): Cell {
     return beginCell()
@@ -10,15 +11,6 @@ function convertToPrunedBranch(c: Cell): Cell {
         .storeUint(1, 8)
         .storeBuffer(c.hash(0))
         .storeUint(c.depth(0), 16)
-        .endCell({ exotic: true });
-}
-
-function convertToMerkleProof(c: Cell): Cell {
-    return beginCell()
-        .storeUint(3, 8)
-        .storeBuffer(c.hash(0))
-        .storeUint(c.depth(0), 16)
-        .storeRef(c)
         .endCell({ exotic: true });
 }
 

--- a/src/dict/generateMerkleUpdate.ts
+++ b/src/dict/generateMerkleUpdate.ts
@@ -21,8 +21,8 @@ export function generateMerkleUpdate<K extends DictionaryKeyTypes, V>(
     keyObject: DictionaryKey<K>,
     newValue: V
 ): Cell {
-    const oldProof = generateMerkleProof(dict, key, keyObject).refs[0];
+    const oldProof = generateMerkleProof(dict, [key], keyObject).refs[0];
     dict.set(key, newValue);
-    const newProof = generateMerkleProof(dict, key, keyObject).refs[0];
+    const newProof = generateMerkleProof(dict, [key], keyObject).refs[0];
     return convertToMerkleUpdate(oldProof, newProof);
 }


### PR DESCRIPTION
1. `generateMerkleProof` now takes an array of keys instead of a single key.
2. new method `generateMerkleProofDirect` generates the pruned dictionary directly without adding the root merkle proof cell. The result can be used as a part of a bigger merkle proof.
3. `convertToMerkleProof` is now exposed to help finishing the proof from `generateMerkleProofDirect`.