### PR TITLE
Export new merkle proof functions + throw on missing keys

### DIFF
--- a/src/dict/Dictionary.spec.ts
+++ b/src/dict/Dictionary.spec.ts
@@ -139,6 +139,8 @@ describe('Dictionary', () => {
                 dictHash
             );
         }
+
+        expect(() => d.generateMerkleProof([6])).toThrow();
     });
 
     it('should generate merkle updates', () => {

--- a/src/dict/generateMerkleProof.ts
+++ b/src/dict/generateMerkleProof.ts
@@ -103,7 +103,11 @@ export function generateMerkleProofDirect<K extends DictionaryKeyTypes, V>(
     keys: K[],
     keyObject: DictionaryKey<K>
 ): Cell {
-    keys = keys.filter((key) => dict.has(key)); 
+    keys.forEach((key) => {
+        if (!dict.has(key)) {
+            throw new Error(`Trying to generate merkle proof for a missing key "${key}"`)
+        }
+    })
     const s = beginCell().storeDictDirect(dict).asSlice();
     return doGenerateMerkleProof(
             '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,12 +28,12 @@ export { Writable } from './boc/Writable';
 export { Dictionary, DictionaryKey, DictionaryKeyTypes, DictionaryValue } from './dict/Dictionary';
 
 // Exotics
-export { exoticMerkleProof } from './boc/cell/exoticMerkleProof';
+export { exoticMerkleProof, convertToMerkleProof } from './boc/cell/exoticMerkleProof';
 export { exoticMerkleUpdate } from './boc/cell/exoticMerkleUpdate';
 export { exoticPruned } from './boc/cell/exoticPruned';
 
 // Merkle trees
-export { generateMerkleProof } from './dict/generateMerkleProof'
+export { generateMerkleProof, generateMerkleProofDirect } from './dict/generateMerkleProof'
 export { generateMerkleUpdate } from './dict/generateMerkleUpdate'
 
 // Tuples


### PR DESCRIPTION
I forgot to export them in the "More flexible merkle proof generation" PR.

Also it's safer to throw on missing keys.