### PR TITLE
Export new merkle proof functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,12 +28,12 @@ export { Writable } from './boc/Writable';
 export { Dictionary, DictionaryKey, DictionaryKeyTypes, DictionaryValue } from './dict/Dictionary';
 
 // Exotics
-export { exoticMerkleProof } from './boc/cell/exoticMerkleProof';
+export { exoticMerkleProof, convertToMerkleProof } from './boc/cell/exoticMerkleProof';
 export { exoticMerkleUpdate } from './boc/cell/exoticMerkleUpdate';
 export { exoticPruned } from './boc/cell/exoticPruned';
 
 // Merkle trees
-export { generateMerkleProof } from './dict/generateMerkleProof'
+export { generateMerkleProof, generateMerkleProofDirect } from './dict/generateMerkleProof'
 export { generateMerkleUpdate } from './dict/generateMerkleUpdate'
 
 // Tuples


### PR DESCRIPTION
I forgot to export them in the "More flexible merkle proof generation" PR.