### PR TITLE
Add Cell.fromHex

### DIFF
--- a/src/boc/Cell.ts
+++ b/src/boc/Cell.ts
@@ -34,11 +34,23 @@ export class Cell {
     }
 
     /**
-     * Helper class that deserializes a single cell from BOC in base64
+     * Helper function that deserializes a single cell from BOC in base64
      * @param src source string
      */
     static fromBase64(src: string): Cell {
         let parsed = Cell.fromBoc(Buffer.from(src, 'base64'));
+        if (parsed.length !== 1) {
+            throw new Error("Deserialized more than one cell");
+        }
+        return parsed[0];
+    }
+
+    /**
+     * Helper function that deserializes a single cell from BOC in hex
+     * @param src source string
+     */
+    static fromHex(src: string): Cell {
+        let parsed = Cell.fromBoc(Buffer.from(src, 'hex'));
         if (parsed.length !== 1) {
             throw new Error("Deserialized more than one cell");
         }

--- a/src/boc/cell/serialization.spec.ts
+++ b/src/boc/cell/serialization.spec.ts
@@ -241,5 +241,10 @@ describe('boc', () => {
         expect(cell.toString()).toBe('x{000000E4}\n x{00000539}\n x{0000053A}');
         expect(serialized).toBe('b5ee9c7281010301001400080e140208000000e4010200080000053900080000053a');
     });
+
+    it('should deserialize cell from hex', () => {
+        let cell = Cell.fromHex('b5ee9c7241010201000d00010800000001010008000000027d4b3cf8');
+        expect(cell.toString()).toBe('x{00000001}\n x{00000002}');
+    });
 });
 


### PR DESCRIPTION
It is sometimes required to parse a Cell from a hex string. Writing `Cell.fromBoc(Buffer.from(s, 'hex'))[0]` is quite cumbersome, so I suggest adding this function.