### PR TITLE
feat/fix: allow ContractProvider.get to accept numbers as method IDs

### DIFF
--- a/src/contract/ContractProvider.ts
+++ b/src/contract/ContractProvider.ts
@@ -26,7 +26,7 @@ export type ContractGetMethodResult = {
 
 export interface ContractProvider {
     getState(): Promise<ContractState>;
-    get(name: string, args: TupleItem[]): Promise<ContractGetMethodResult>;
+    get(name: string | number, args: TupleItem[]): Promise<ContractGetMethodResult>;
     external(message: Cell): Promise<void>;
     internal(via: Sender, args: { value: bigint | string, bounce?: Maybe<boolean>, sendMode?: SendMode, body?: Maybe<Cell | string> }): Promise<void>;
     open<T extends Contract>(contract: T): OpenedContract<T>;


### PR DESCRIPTION
Sandbox supports both strings and numbers to call getters.