### PR TITLE
fix: always pop current element in `readStringOpt` and `readBufferOpt`

### DIFF
--- a/src/tuple/reader.ts
+++ b/src/tuple/reader.ts
@@ -185,18 +185,16 @@ export class TupleReader {
     }
 
     readBufferOpt() {
-        let popped = this.peek();
-        if (popped.type === 'null') {
+        let r = this.readCellOpt();
+        if (r !== null) {
+            let s = r.beginParse();
+            if (s.remainingRefs !== 0 || s.remainingBits % 8 !== 0) {
+                throw Error('Not a buffer');
+            }
+            return s.loadBuffer(s.remainingBits / 8);
+        } else {
             return null;
-        }
-        let s = this.readCell().beginParse();
-        if (s.remainingRefs !== 0) {
-            throw Error('Not a buffer');
-        }
-        if (s.remainingBits % 8 !== 0) {
-            throw Error('Not a buffer');
-        }
-        return s.loadBuffer(s.remainingBits / 8);
+	}
     }
 
     readString() {
@@ -205,11 +203,13 @@ export class TupleReader {
     }
 
     readStringOpt() {
-        let popped = this.peek();
-        if (popped.type === 'null') {
+        let r = this.readCellOpt();
+        if (r !== null) {
+            let s = r.beginParse();
+            return s.loadStringTail();
+        } else {
             return null;
         }
-        let s = this.readCell().beginParse();
-        return s.loadStringTail();
     }
 }
+


### PR DESCRIPTION
In the case of null elements, the current stack element wasn't popped which caused incorrect processing of the subsequent tuple elements.

Here is the issue in Tact https://github.com/tact-lang/tact/issues/918 where this bug manifests itself.