### PR TITLE
fix: builder.writeInt(0, 1); // value is not zero or -1 for 1 bits. Got 0

### DIFF
--- a/src/boc/BitBuilder.spec.ts
+++ b/src/boc/BitBuilder.spec.ts
@@ -255,4 +255,20 @@ describe('BitBuilder', () => {
             expect(bits.toString()).toBe(c[1]);
         }
     });
+
+    it('should store bigint and number for len 1', () => {
+      let builder = new BitBuilder();
+      builder.writeInt(0, 1)
+      builder.writeInt(0n, 1)
+      builder.writeInt(-1, 1)
+      builder.writeInt(-1n, 1)
+      expect(builder.length).toBe(4)
+    })
+
+    it('should store bigint and number for len 0', () => {
+      let builder = new BitBuilder();
+      builder.writeInt(0, 0)
+      builder.writeInt(0n, 0)
+      expect(builder.length).toBe(0)
+    })
 });

--- a/src/boc/BitBuilder.ts
+++ b/src/boc/BitBuilder.ts
@@ -152,7 +152,7 @@ export class BitBuilder {
 
         // Corner case for zero bits
         if (bits === 0) {
-            if (value !== 0n) {
+            if (v !== 0n) {
                 throw Error(`value is not zero for ${bits} bits. Got ${value}`);
             } else {
                 return;
@@ -161,7 +161,7 @@ export class BitBuilder {
 
         // Corner case for one bit
         if (bits === 1) {
-            if (value !== -1n && value !== 0n) {
+            if (v !== -1n && v !== 0n) {
                 throw Error(`value is not zero or -1 for ${bits} bits. Got ${value}`);
             } else {
                 this.writeBit(value === -1n);


### PR DESCRIPTION
This code will throw an error, but should work
```js
let builder = new BitBuilder();
builder.writeInt(0, 1); // value is not zero or -1 for 1 bits. Got 0
```
The error occurs because the variable `value` is checked on line 155 instead of `v` from line 148.
value can be a number or a BigInt, so comparing it with BigInt constants will not work.

https://github.com/ton-org/ton-core/blob/00fa47e03c2a78c6dd9d09e517839685960bc2fd/src/boc/BitBuilder.ts#L147-L160

Same problem with 
```js
builder.writeInt(0, 0);
builder.writeInt(-1, 1);
```
