### PR TITLE
Draft: fix: correct serialization for addresses

### DIFF
--- a/src/boc/BitBuilder.ts
+++ b/src/boc/BitBuilder.ts
@@ -290,6 +290,26 @@ export class BitBuilder {
         throw Error(`Invalid address. Got ${address}`);
     }
 
+    writeAddress1(address: Address | ExternalAddress | "none") {
+        // Is empty address
+        if (address === "none") {
+            this.writeUint(0, 2); // Empty address
+            return;
+        }
+
+        this.writeAddress(address);
+    }
+
+    writeMaybeAddress1(address: Maybe<Address | ExternalAddress | "none">) {
+        if (address === null || address === undefined) {
+            this.writeUint(0, 1);
+            return;
+        }
+
+        this.writeUint(1, 1);
+        this.writeAddress1(address);
+    }
+
     /**
      * Build BitString
      * @returns result bit string

--- a/src/boc/BitReader.ts
+++ b/src/boc/BitReader.ts
@@ -328,6 +328,32 @@ export class BitReader {
         }
     }
 
+    loadAddress1() {
+        let type = Number(this._preloadUint(2, this._offset));
+        if (type === 0) {
+            return 'none' as const;
+        } else if (type === 1) {
+            return this._loadExternalAddress();
+        } else if (type === 2) {
+            return this._loadInternalAddress();
+        } else {
+            throw new Error("Unsupported address type: " + type);
+        }
+    }
+
+    loadMaybeAddress1() {
+        let type = Number(this._preloadUint(1, this._offset));
+        if (type === 0) {
+            this._offset += 1;
+            return null;
+        } else if (type === 1) {
+            this._offset += 1;
+            return this.loadAddress1();
+        } else {
+            throw new Error("Invalid maybe");
+        }
+    }
+
     /**
      * Load external address
      * @returns ExternalAddress

--- a/src/boc/Builder.ts
+++ b/src/boc/Builder.ts
@@ -260,6 +260,16 @@ export class Builder {
         return this;
     }
 
+    storeAddress1(address: Address | ExternalAddress | "none") {
+        this._bits.writeAddress1(address);
+        return this;
+    }
+
+    storeMaybeAddress1(address: Maybe<Address | ExternalAddress | "none">) {
+        this._bits.writeMaybeAddress1(address);
+        return this;
+    }
+
     /**
      * Store reference
      * @param cell cell or builder to store

--- a/src/boc/Slice.ts
+++ b/src/boc/Slice.ts
@@ -360,6 +360,22 @@ export class Slice {
     }
 
     /**
+     * Load internal Address
+     * @returns Address
+     */
+    loadAddress1() {
+        return this._reader.loadAddress1();
+    }
+
+    /**
+     * Load optional internal Address
+     * @returns Address or null
+     */
+    loadMaybeAddress1() {
+        return this._reader.loadMaybeAddress1();
+    }
+
+    /**
      * Load external address
      * @returns ExternalAddress
      */

--- a/src/tuple/reader.ts
+++ b/src/tuple/reader.ts
@@ -106,6 +106,24 @@ export class TupleReader {
         }
     }
 
+    readAddress1() {
+        let r = this.readCell().beginParse().loadAddress1();
+        if (r !== null) {
+            return r;
+        } else {
+            throw Error('Not an address');
+        }
+    }
+
+    readAddressOpt1() {
+        let r = this.readCellOpt();
+        if (r !== null) {
+            return r.beginParse().loadMaybeAddress1();
+        } else {
+            return null;
+        }
+    }
+
     readCell() {
         let popped = this.pop();
         if (popped.type !== 'cell' && popped.type !== 'slice' && popped.type !== 'builder') {


### PR DESCRIPTION
It seems address serialization is incorrect. Relevant parts of TL-B schema

https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb#L8-L9

https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb#L100-L110

