### PR TITLE
feat: enhance toNano and fromNano functions to support customizable decimal precision

### DIFF
--- a/src/utils/convert.spec.ts
+++ b/src/utils/convert.spec.ts
@@ -1,67 +1,90 @@
 /**
- * Copyright (c) Whales Corp. 
+ * Copyright (c) Whales Corp.
  * All Rights Reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { fromNano, toNano } from "./convert";
+import { fromNano, toNano } from './convert';
 
-const stringCases: { nano: string, real: string }[] = [
-    { real: '1', nano: '1000000000' },
-    { real: '10', nano: '10000000000' },
-    { real: '0.1', nano: '100000000' },
-    { real: '0.33', nano: '330000000' },
-    { real: '0.000000001', nano: '1' },
-    { real: '10.000000001', nano: '10000000001' },
-    { real: '1000000.000000001', nano: '1000000000000001' },
-    { real: '100000000000', nano: '100000000000000000000' },
+const stringCases: { nano: string; real: string }[] = [
+	{ real: '1', nano: '1000000000' },
+	{ real: '10', nano: '10000000000' },
+	{ real: '0.1', nano: '100000000' },
+	{ real: '0.33', nano: '330000000' },
+	{ real: '0.000000001', nano: '1' },
+	{ real: '10.000000001', nano: '10000000001' },
+	{ real: '1000000.000000001', nano: '1000000000000001' },
+	{ real: '100000000000', nano: '100000000000000000000' },
 ];
 
-const numberCases: { nano: string, real: number }[] = [
-    { real: -0, nano: '0' },
-    { real: 0, nano: '0' },
-    { real: 1e64, nano: '10000000000000000000000000000000000000000000000000000000000000000000000000' },
-    { real: 1, nano: '1000000000' },
-    { real: 10, nano: '10000000000' },
-    { real: 0.1, nano: '100000000' },
-    { real: 0.33, nano: '330000000' },
-    { real: 0.000000001, nano: '1' },
-    { real: 10.000000001, nano: '10000000001' },
-    { real: 1000000.000000001, nano: '1000000000000001' },
-    { real: 100000000000, nano: '100000000000000000000' },
+const numberCases: { nano: string; real: number }[] = [
+	{ real: -0, nano: '0' },
+	{ real: 0, nano: '0' },
+	{
+		real: 1e64,
+		nano: '10000000000000000000000000000000000000000000000000000000000000000000000000',
+	},
+	{ real: 1, nano: '1000000000' },
+	{ real: 10, nano: '10000000000' },
+	{ real: 0.1, nano: '100000000' },
+	{ real: 0.33, nano: '330000000' },
+	{ real: 0.000000001, nano: '1' },
+	{ real: 10.000000001, nano: '10000000001' },
+	{ real: 1000000.000000001, nano: '1000000000000001' },
+	{ real: 100000000000, nano: '100000000000000000000' },
 ];
 
 describe('convert', () => {
-    it('should throw an error for NaN', () => {
-        expect(() => toNano(NaN)).toThrow();
-    });
-    it('should throw an error for Infinity', () => {
-        expect(() => toNano(Infinity)).toThrow();
-    });
-    it('should throw an error for -Infinity', () => {
-        expect(() => toNano(-Infinity)).toThrow();
-    });
-    it('should throw an error due to insufficient precision of number', () => {
-        expect(() => toNano(10000000.000000001)).toThrow();
-    });
-    it('should convert numbers toNano', () => {
-        for (let r of numberCases) {
-            let c = toNano(r.real);
-            expect(c).toBe(BigInt(r.nano));
-        }
-    });
-    it('should convert strings toNano', () => {
-        for (let r of stringCases) {
-            let c = toNano(r.real);
-            expect(c).toBe(BigInt(r.nano));
-        }
-    });
-    it('should convert fromNano', () => {
-        for (let r of stringCases) {
-            let c = fromNano(r.nano);
-            expect(c).toEqual(r.real);
-        }
-    });
+	it('should throw an error for NaN', () => {
+		expect(() => toNano(NaN)).toThrow();
+	});
+	it('should throw an error for Infinity', () => {
+		expect(() => toNano(Infinity)).toThrow();
+	});
+	it('should throw an error for -Infinity', () => {
+		expect(() => toNano(-Infinity)).toThrow();
+	});
+	it('should throw an error due to insufficient precision of number', () => {
+		expect(() => toNano(10000000.000000001)).toThrow();
+	});
+	it('should convert numbers toNano', () => {
+		for (let r of numberCases) {
+			let c = toNano(r.real);
+			expect(c).toBe(BigInt(r.nano));
+		}
+	});
+	it('should convert strings toNano', () => {
+		for (let r of stringCases) {
+			let c = toNano(r.real);
+			expect(c).toBe(BigInt(r.nano));
+		}
+	});
+	it('should convert fromNano', () => {
+		for (let r of stringCases) {
+			let c = fromNano(r.nano);
+			expect(c).toEqual(r.real);
+		}
+	});
+	it('should convert numbers toNano with custom decimals', () => {
+		expect(toNano(1, 6)).toBe(BigInt('1000000'));
+		expect(toNano(0.1, 6)).toBe(BigInt('100000'));
+		expect(toNano(0.000001, 6)).toBe(BigInt('1'));
+		expect(toNano(10.000001, 6)).toBe(BigInt('10000001'));
+	});
+
+	it('should convert strings toNano with custom decimals', () => {
+		expect(toNano('1', 6)).toBe(BigInt('1000000'));
+		expect(toNano('0.1', 6)).toBe(BigInt('100000'));
+		expect(toNano('0.000001', 6)).toBe(BigInt('1'));
+		expect(toNano('10.000001', 6)).toBe(BigInt('10000001'));
+	});
+
+	it('should convert fromNano with custom decimals', () => {
+		expect(fromNano('1000000', 6)).toEqual('1');
+		expect(fromNano('100000', 6)).toEqual('0.1');
+		expect(fromNano('1', 6)).toEqual('0.000001');
+		expect(fromNano('10000001', 6)).toEqual('10.000001');
+	});
 });

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,96 +1,105 @@
 /**
- * Copyright (c) Whales Corp. 
+ * Copyright (c) Whales Corp.
  * All Rights Reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-export function toNano(src: number | string | bigint): bigint {
+export function toNano(
+	src: number | string | bigint,
+	decimals: number = 9
+): bigint {
+	if (typeof src === 'bigint') {
+		return src * 10n ** BigInt(decimals);
+	} else {
+		if (typeof src === 'number') {
+			if (!Number.isFinite(src)) {
+				throw Error('Invalid number');
+			}
 
-    if (typeof src === 'bigint') {
-        return src * 1000000000n;
-    } else {
-        if (typeof src === 'number') {
-            if (!Number.isFinite(src)) {
-                throw Error('Invalid number');
-            }
+			if (Math.log10(src) <= 6) {
+				src = src.toLocaleString('en', {
+					minimumFractionDigits: decimals,
+					useGrouping: false,
+				});
+			} else if (src - Math.trunc(src) === 0) {
+				src = src.toLocaleString('en', {
+					maximumFractionDigits: 0,
+					useGrouping: false,
+				});
+			} else {
+				throw Error(
+					'Not enough precision for a number value. Use string value instead'
+				);
+			}
+		}
+		// Check sign
+		let neg = false;
+		while (src.startsWith('-')) {
+			neg = !neg;
+			src = src.slice(1);
+		}
 
-            if (Math.log10(src) <= 6) {
-                src = src.toLocaleString('en', { minimumFractionDigits: 9, useGrouping: false });
-            } else if (src - Math.trunc(src) === 0) {
-                src = src.toLocaleString('en', { maximumFractionDigits: 0, useGrouping: false });
-            } else {
-                throw Error('Not enough precision for a number value. Use string value instead');
-            }
-        }
+		// Split string
+		if (src === '.') {
+			throw Error('Invalid number');
+		}
+		let parts = src.split('.');
+		if (parts.length > 2) {
+			throw Error('Invalid number');
+		}
 
-        // Check sign
-        let neg = false;
-        while (src.startsWith('-')) {
-            neg = !neg;
-            src = src.slice(1);
-        }
+		// Prepare parts
+		let whole = parts[0];
+		let frac = parts[1];
+		if (!whole) {
+			whole = '0';
+		}
+		if (!frac) {
+			frac = '0';
+		}
+		if (frac.length > decimals) {
+			throw Error('Invalid number');
+		}
+		while (frac.length < decimals) {
+			frac += '0';
+		}
 
-        // Split string
-        if (src === '.') {
-            throw Error('Invalid number');
-        }
-        let parts = src.split('.');
-        if (parts.length > 2) {
-            throw Error('Invalid number');
-        }
-
-        // Prepare parts
-        let whole = parts[0];
-        let frac = parts[1];
-        if (!whole) {
-            whole = '0';
-        }
-        if (!frac) {
-            frac = '0';
-        }
-        if (frac.length > 9) {
-            throw Error('Invalid number');
-        }
-        while (frac.length < 9) {
-            frac += '0';
-        }
-
-        // Convert
-        let r = BigInt(whole) * 1000000000n + BigInt(frac);
-        if (neg) {
-            r = -r;
-        }
-        return r;
-    }
+		// Convert
+		let r = BigInt(whole) * 10n ** BigInt(decimals) + BigInt(frac);
+		if (neg) {
+			r = -r;
+		}
+		return r;
+	}
 }
 
-export function fromNano(src: bigint | number | string) {
-    let v = BigInt(src);
-    let neg = false;
-    if (v < 0) {
-        neg = true;
-        v = -v;
-    }
+export function fromNano(src: bigint | number | string, decimals: number = 9) {
+	let v = BigInt(src);
+	let neg = false;
+	if (v < 0) {
+		neg = true;
+		v = -v;
+	}
 
-    // Convert fraction
-    let frac = v % 1000000000n;
-    let facStr = frac.toString();
-    while (facStr.length < 9) {
-        facStr = '0' + facStr;
-    }
-    facStr = facStr.match(/^([0-9]*[1-9]|0)(0*)/)![1];
+	// Convert fraction
+	let frac = v % 10n ** BigInt(decimals);
+	let facStr = frac.toString();
+	while (facStr.length < decimals) {
+		facStr = '0' + facStr;
+	}
+	facStr = facStr.match(/^([0-9]*[1-9]|0)(0*)/)![1];
 
-    // Convert whole
-    let whole = v / 1000000000n;
-    let wholeStr = whole.toString();
+	// Convert whole
+	let whole = v / 10n ** BigInt(decimals);
+	let wholeStr = whole.toString();
 
-    // Value
-    let value = `${wholeStr}${facStr === '0' ? '' : `.${facStr}`}`;
-    if (neg) {
-        value = '-' + value;
-    }
+	// Value
+	let value = `${wholeStr}${facStr === '0' ? '' : `.${facStr}`}`;
+	if (neg) {
+		value = '-' + value;
+	}
 
-    return value;
+	return value;
 }


### PR DESCRIPTION
This pull request includes changes to the `src/utils/convert.ts` and `src/utils/convert.spec.ts` files to add support for custom decimal places in the `toNano` and `fromNano` functions. Additionally, it includes minor code style adjustments.

### Support for custom decimals:
* [`src/utils/convert.ts`](diffhunk://#diff-48eee415b915d7a00582aeb82fd83180954ea6a93f34469545bf62952ac62248L9-L27): Modified `toNano` and `fromNano` functions to accept an optional `decimals` parameter, allowing conversion with custom decimal places. [[1]](diffhunk://#diff-48eee415b915d7a00582aeb82fd83180954ea6a93f34469545bf62952ac62248L9-L27) [[2]](diffhunk://#diff-48eee415b915d7a00582aeb82fd83180954ea6a93f34469545bf62952ac62248L53-R78) [[3]](diffhunk://#diff-48eee415b915d7a00582aeb82fd83180954ea6a93f34469545bf62952ac62248L78-R95)
* [`src/utils/convert.spec.ts`](diffhunk://#diff-7fde678dd575f76640f536114e2564c61e7a5f4b5dbe388b3af2a7ad9ec2dc1eR70-R89): Added test cases to verify the functionality of `toNano` and `fromNano` with custom decimal places.

### Code style adjustments:
* [`src/utils/convert.spec.ts`](diffhunk://#diff-7fde678dd575f76640f536114e2564c61e7a5f4b5dbe388b3af2a7ad9ec2dc1eL9-R11): Changed object property separators from commas to semicolons for consistency. [[1]](diffhunk://#diff-7fde678dd575f76640f536114e2564c61e7a5f4b5dbe388b3af2a7ad9ec2dc1eL9-R11) [[2]](diffhunk://#diff-7fde678dd575f76640f536114e2564c61e7a5f4b5dbe388b3af2a7ad9ec2dc1eL22-R28)