### PR TITLE
Regex in isFriendly should be anchored

### DIFF
--- a/src/address/Address.spec.ts
+++ b/src/address/Address.spec.ts
@@ -61,10 +61,12 @@ describe('Address', () => {
         expect(() => {
             Address.parseRaw('0:2cf55953e92efbeadab7ba725c3f93a0b23f842cbba72d7b8e6f510a70e422');
         }).toThrowError('Invalid address hash length: 31');
+        expect(Address.isRaw('0:2cf55953e92efbeadab7ba725c3f93a0b23f842cbba72d7b8e6f510a70e422')).toBe(false);
 
         expect(() => {
             Address.parseRaw('0:2cf55953e92efbeadab7ba725c3f93a0b23f842cbba72d7b8e6f510a70e422e');
         }).toThrowError('Invalid address hash length: 31');
+        expect(Address.isRaw('0:2cf55953e92efbeadab7ba725c3f93a0b23f842cbba72d7b8e6f510a70e422e')).toBe(false);
 
         expect(() => {
             Address.parse('ton://EQAs9VlT6S776tq3unJcP5Ogsj-ELLunLXuOb1EKcOQi4wJB')
@@ -81,9 +83,21 @@ describe('Address', () => {
         expect(() => {
             Address.parseFriendly('ton://transfer/EQDXDCFLXgiTrjGSNVBuvKPZVYlPn3J_u96xxLas3_yoRWRk')
         }).toThrowError('Unknown address type');
+        expect(Address.isFriendly('ton://transfer/EQDXDCFLXgiTrjGSNVBuvKPZVYlPn3J_u96xxLas3_yoRWRk')).toBe(false);
 
         expect(() => {
             Address.parseFriendly('0:EQDXDCFLXgiTrjGSNVBuvKPZVYlPn3J_u96xxLas3_yoRWRk')
         }).toThrowError('Unknown address type');
+        expect(Address.isFriendly('0:EQDXDCFLXgiTrjGSNVBuvKPZVYlPn3J_u96xxLas3_yoRWRk')).toBe(false)
+
+        expect(() => {
+            Address.parseFriendly('!@#$%^&*AAAAAAAAAAAAAA AAAAAAAAAA AAAAAAAAAAAA A')
+        }).toThrowError('Unknown address type');
+        expect(Address.isFriendly('!@#$%^&*AAAAAAAAAAAAAA AAAAAAAAAA AAAAAAAAAAAA A')).toBe(false)
+
+        expect(() => {
+            Address.parseFriendly('                                                ')
+        }).toThrowError('Unknown address type');
+        expect(Address.isFriendly('                                                ')).toBe(false)
     });
 });

--- a/src/address/Address.ts
+++ b/src/address/Address.ts
@@ -71,7 +71,7 @@ export class Address {
             return false;
         }
         // Check if address is valid base64
-        if (!/[A-Za-z0-9+/_-]+/.test(source)) {
+        if (!/^[A-Za-z0-9+/_-]+$/.test(source)) {
             return false;
         }
 


### PR DESCRIPTION
I think I found few issues with addresses.

1. regex in `isFriendly` should be anchored otherwise it returns `true` for invalid addresses 
  _parse fails as it should, problem is `isFriendly` not `parseFriendly`_
2. addresses for which `parseRaw` throws should also return `false` from `isRaw`
3. addresses for which `parseFriendly` throws should also return `false` from `isFriendly`

You can verify by using my tests without change in `isFriendly` and see that address `!@#$%^&*AAAAAAAAAAAAAA AAAAAAAAAA AAAAAAAAAAAA A` is considered to be friendly:

```
 FAIL  src/address/Address.spec.ts
  Address
    ✓ should parse addresses in various forms (3 ms)
    ✓ should serialize to friendly form
    ✓ should implement equals
    ✕ should throw if address is invalid (8 ms)

  ● Address › should throw if address is invalid

    expect(received).toBe(expected) // Object.is equality

    Expected: false
    Received: true

      94 |             Address.parseFriendly('!@#$%^&*AAAAAAAAAAAAAA AAAAAAAAAA AAAAAAAAAAAA A')
      95 |         }).toThrowError('Unknown address type');
    > 96 |         expect(Address.isFriendly('!@#$%^&*AAAAAAAAAAAAAA AAAAAAAAAA AAAAAAAAAAAA A')).toBe(false)
```