### PR TITLE
feat: add method for preload bit selector

### DIFF
--- a/src/boc/Slice.spec.ts
+++ b/src/boc/Slice.spec.ts
@@ -13,6 +13,34 @@ import { BitBuilder } from './BitBuilder';
 import { Cell } from './Cell';
 
 describe('Slice', () => {
+    it('should read bit selector from slice', () => {
+        const builder = new BitBuilder();
+        builder.writeUint(0b00, 2); // f_a$00 = Foo
+        builder.writeUint(0b01, 2); // f_b$01 = Foo
+        builder.writeUint(0b10, 2); // f_c$10 = Foo
+        builder.writeUint(0b10, 2); // b_b$10 = Bar
+        builder.writeUint(0b11, 2); // b_c$11 = Bar
+        builder.writeUint(0b0, 1);  // b_a$0  = Bar
+        const bits = builder.build();
+        const reader = new Cell({ bits }).beginParse();
+        expect(reader.preloadBitSelector(7, 0)).toEqual(-1);
+        const prefixUsefulDepth = 2;
+        let mask = 0b111;
+        expect(reader.preloadBitSelector(prefixUsefulDepth, mask)).toEqual(0);
+        reader.skip(2);
+        expect(reader.preloadBitSelector(prefixUsefulDepth, mask)).toEqual(1);
+        reader.skip(2);
+        expect(reader.preloadBitSelector(prefixUsefulDepth, mask)).toEqual(2);
+        reader.skip(2);
+        mask = 0b1101;
+        expect(reader.preloadBitSelector(prefixUsefulDepth, mask, true)).toEqual(1);
+        reader.skip(2);
+        expect(reader.preloadBitSelector(prefixUsefulDepth, mask, true)).toEqual(2);
+        reader.skip(2);
+        expect(reader.preloadBitSelector(prefixUsefulDepth, mask)).toEqual(-1);
+        expect(reader.preloadBitSelector(prefixUsefulDepth, mask, true)).toEqual(0);
+    });
+
     it('should read uints from slice', () => {
         let prando = new Prando('test-1');
         for (let i = 0; i < 1000; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export {
 export { toNano, fromNano } from './utils/convert';
 export { crc16 } from './utils/crc16';
 export { crc32c } from './utils/crc32c';
+export { countBits64 } from './utils/countBits64';
 export { base32Decode, base32Encode } from './utils/base32';
 export { getMethodId } from './utils/getMethodId';
 

--- a/src/utils/countBits64.ts
+++ b/src/utils/countBits64.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Whales Corp.
+ * All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export function countBits64(x: number): number {
+  let count = 0;
+  while (x) {
+    count++;
+    x &= (x - 1);
+  }
+  return count;
+}


### PR DESCRIPTION
methods [CellSlice::bselect and CellSlice::bselect_ext](https://github.com/ton-blockchain/ton/blob/ce6c29941ea1e29a10c266ef615fb3302213642d/crypto/vm/cells/CellSlice.cpp#L572-L592) of reading a slice are ported, they are needed to implement generation tools based on the TL-B scheme