### PR TITLE
refactor: use `base64url` instead hardcoded implementation and `toString` doc comment

### DIFF
--- a/src/address/Address.spec.ts
+++ b/src/address/Address.spec.ts
@@ -45,6 +45,18 @@ describe('Address', () => {
         expect(address.toString({ bounceable: false, urlSafe: false })).toMatch('UQAs9VlT6S776tq3unJcP5Ogsj+ELLunLXuOb1EKcOQi41+E');
         expect(address.toString({ bounceable: false, urlSafe: false, testOnly: true })).toMatch('0QAs9VlT6S776tq3unJcP5Ogsj+ELLunLXuOb1EKcOQi4+QO');
     });
+    it('should serialize with urlSafe=false', () => {
+        const address = Address.parseRaw('0:2cf55953e92efbeadab7ba725c3f93a0b23f842cbba72d7b8e6f510a70e422e3');
+
+        // Bounceable
+        expect(address.toString({ testOnly: true })).toMatch('kQAs9VlT6S776tq3unJcP5Ogsj-ELLunLXuOb1EKcOQi47nL');
+        expect(address.toString({ urlSafe: false })).toMatch('EQAs9VlT6S776tq3unJcP5Ogsj+ELLunLXuOb1EKcOQi4wJB');
+        expect(address.toString({ urlSafe: false, testOnly: true })).toMatch('kQAs9VlT6S776tq3unJcP5Ogsj+ELLunLXuOb1EKcOQi47nL');
+
+        // Non-Bounceable
+        expect(address.toString({ bounceable: false, urlSafe: false })).toMatch('UQAs9VlT6S776tq3unJcP5Ogsj+ELLunLXuOb1EKcOQi41+E');
+        expect(address.toString({ bounceable: false, urlSafe: false, testOnly: true })).toMatch('0QAs9VlT6S776tq3unJcP5Ogsj+ELLunLXuOb1EKcOQi4+QO');
+    });
     it('should implement equals', () => {
         let address1 = Address.parseRaw('0:2cf55953e92efbeadab7ba725c3f93a0b23f842cbba72d7b8e6f510a70e422e3');
         let address2 = Address.parseRaw('0:2cf55953e92efbeadab7ba725c3f93a0b23f842cbba72d7b8e6f510a70e422e3');

--- a/src/address/Address.ts
+++ b/src/address/Address.ts
@@ -198,14 +198,19 @@ export class Address {
         return addressWithChecksum;
     }
 
+    /**
+     * Returns address as a string.
+     *
+     * @param args optional arguments with the following properties:
+     * - urlSafe — if true (default), returns url-friendly string, otherwise just base64
+     * - bounceable — if true (default), returns bounceable address (with 0x11 tag),
+     *   otherwise — non-bounceable (with 0x51 tag)
+     * - testOnly — if true (by default, false), returns test-only address (with 0x80 tag), otherwise - non-test-only
+     */
     toString = (args?: { urlSafe?: boolean, bounceable?: boolean, testOnly?: boolean }) => {
-        let urlSafe = (args && args.urlSafe !== undefined) ? args.urlSafe : true;
-        let buffer = this.toStringBuffer(args);
-        if (urlSafe) {
-            return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_');
-        } else {
-            return buffer.toString('base64');
-        }
+        const urlSafe = (args && args.urlSafe !== undefined) ? args.urlSafe : true;
+        const buffer = this.toStringBuffer(args);
+        return urlSafe ? buffer.toString('base64url') : buffer.toString('base64');
     }
 
     [inspectSymbol] = () => this.toString()


### PR DESCRIPTION

Fixes #83